### PR TITLE
Add initial .gitpod.yml and tasks.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,28 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - name: Install opensafely cli tool
+    # runs when workspace initially created, and as pre-build
+    init: |
+        pip install opensafely
+        opensafely pull --project project.yaml
+  - name: Update opensafely
+    # run every time you open a workspace
+    command:
+        opensafely upgrade
+
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+---
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
   - name: Install opensafely cli tool
@@ -33,3 +34,4 @@ vscode:
     - vscode.html-language-features
     - redhat.vscode-yaml
     - ikuyadeu.r
+    - randomfractalsinc.vscode-data-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,3 +26,10 @@ github:
     addComment: true
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: false
+
+vscode:
+  extensions:
+    - ms-python.python
+    - vscode.html-language-features
+    - redhat.vscode-yaml
+    - ikuyadeu.r

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true,
+    "data.preview.create.json.schema": false,
+    "files.associations": {
+        "*.feather": "arrow",
+    },
+    "window.autoDetectColorScheme": true,
+    "extensions.ignoreRecommendations": true,
+    "data.preview.theme": "light"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "OpenSAFELY run project",
+            "type": "shell",
+            "command": "opensafely run run_all -f",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "new",
+                "showReuseMessage": false,
+                "clear": true,
+            }
+        }
+    ]
+}

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -1,4 +1,4 @@
-from cohortextractor import StudyDefinition, patients, codelist, codelist_from_csv
+from cohortextractor import StudyDefinition, patients, codelist, codelist_from_csv  # NOQA
 
 
 study = StudyDefinition(


### PR DESCRIPTION
This adds initial workspace config for a default opensafely project.

When ever anything is pushed to master, gitpod should run the `init` steps and cache the resulting docker image as a `prebuild`. Any subsequent launches of gitpod for this repo will use the prebuild workspace.

All the prebuild currently does is install opensafely cli tool, and pull down the docker images that are used in this project, and enable some default extensions.

Additionally, whenever a workspace is re-opened, it automatically updates the opensafely cli tool.

In addition, we add a custom vscode build task, which runs the project. This can be accessed via the Terminal->Tasks menu and also by the default build command, Ctrl-Shift-B.

