### PR TITLE
Attempt some basic on-fork templating

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,24 @@
+name: Setup repository
+on:
+  fork:
+jobs:
+  setup:
+    name: Initialise OpenSAFELY project fork.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update README.md
+        shell: bash
+        run: |
+          export GITHUB_REPOSITORY_OWNER="$(echo $GITHUB_REPOSITORY | awk -F/ '{print $1}')"
+          export GITHUB_REPOSITORY_NAME="$(echo $GITHUB_REPOSITORY | awk -F/ '{print $2}')"
+          envsubst < README.md > tmp && mv tmp README.md
+      - name: Remove setup workflow
+        run: rm .github/workflows/setup.yaml
+      - name:
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add .
+          git commit -m 'Setup repository'
+          git push origin main --force-with-lease

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,24 +1,43 @@
 name: Setup repository
 on:
-  fork:
+  workflow_dispatch:
+  push:
+      branches: [main]
 jobs:
   setup:
-    name: Initialise OpenSAFELY project fork.
+    name: Initialise OpenSAFELY project.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update README.md
+      - name: Update README.md and remove action
         shell: bash
         run: |
           export GITHUB_REPOSITORY_OWNER="$(echo $GITHUB_REPOSITORY | awk -F/ '{print $1}')"
           export GITHUB_REPOSITORY_NAME="$(echo $GITHUB_REPOSITORY | awk -F/ '{print $2}')"
           envsubst < README.md > tmp && mv tmp README.md
-      - name: Remove setup workflow
-        run: rm .github/workflows/setup.yaml
-      - name:
+          rm .github/workflows/setup.yaml
+      - name: Do not run on template repository
+        id: is_template
+        # The only way to trigger this to run when used as a template is on
+        # push to main.  But that means it would also trigger when we push to
+        # the template repo itself, which we do not want. So, check if we are
+        # in a template repo
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          is_template=false
+          curl --silent -X GET \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.baptiste-preview+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY \
+            | jq --exit-status '.is_template == false' || is_template=true
+          # output true/false so later actions can be skipped
+          echo "::set-output name=is_template::$is_template"
+      - name: Commit changes
+        # only actually commit the changes if this is not a template repo
+        if: steps.is_template.outputs.is_template == 'false'
+        run: |
+          # use the same author as the initial commit
+          git config user.email "$(git log -1 --pretty=format:'%ae')"
+          git config user.name "$(git log -1 --pretty=format:'%an')"
           git add .
-          git commit -m 'Setup repository'
-          git push origin main --force-with-lease
+          git commit --amend --no-edit
+          git push origin main --force

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# {{project_name}}
+# ${GITHUB_REPOSITORY_NAME}
 
-This is the code and configuration for {{project_name}}
+This is the code and configuration for ${GITHUB_REPOSITORY_NAME}.
+
+You can run this project via [Gitpod](https://gitpod.io): [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/${GITHUB_REPOSITORY})
 
 * The paper is [here]()
 * Raw model outputs, including charts, crosstabs, etc, are in `released_outputs/`


### PR DESCRIPTION
This provides some basic filling in of template values, and in particular, a gitpod button in the README for the new repo.

It seems it is impossible to test this without merging to master, as you cannot a) fork a template without triggering the templating logic and b) base your template of a non-default branch.

So merge to master it is then!