### PR TITLE
Update default branch to `main`

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -2,7 +2,7 @@ name: Setup repository
 on:
   workflow_dispatch:
   push:
-      branches: [master]
+      branches: [main]
 jobs:
   setup:
     name: Initialise OpenSAFELY project.


### PR DESCRIPTION
Following rename of `master` to `main`.

Think this should fix the workflow not running,
as reported by @JRPearson500 on Slack.