### PR TITLE
ignore macOS .DS_Store system files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 output/*
 metadata/*
 venv/
+.DS_Store


### PR DESCRIPTION
This is very minor - but macOS users keep accidentally committing `.DS_Store` files into repos (which are just some macOS system file which don't need committing).

Really they should set this as a global git setting, but this feels like a helpful addition for them.