### PR TITLE
Set default behaviour for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
 # ensure unix line endings on windows for files that need them.
 *.sh eol=lf
 codelists/* eol=lf


### PR DESCRIPTION
I think our users are seeing merge conflicts due to different line endings (i.e., we have users on Windows and Mac).

So I don't think there's any harm setting this at the top of the .gitattributes file to help them out.