### PR TITLE
Update to research-action v2

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -11,5 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test the project can run, using dummy data
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Test that the project is runnable
       uses: opensafely-core/research-action@v2

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -5,10 +5,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}
   STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
+  HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Test the project can run, using dummy data
     steps:
     - name: Test that the project is runnable
-      uses: opensafely-core/research-action@v1
+      uses: opensafely-core/research-action@v2


### PR DESCRIPTION
Depends on https://github.com/opensafely-core/research-action/pull/49 (and a new tag)