### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Initialise OpenSAFELY project.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update README.md and remove action
         shell: bash
         run: |

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -12,6 +12,6 @@ jobs:
     name: Test the project can run, using dummy data
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Test that the project is runnable
       uses: opensafely-core/research-action@v2


### PR DESCRIPTION
`actions/checkout` was on the older v2.

This PR updates that action, and enables Dependabot to keep it updated in future.

Note that as this will also update researcher repositories that are created from this template.