### PR TITLE
Hardcode GitHub org in View on OpenSAFELY URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ${GITHUB_REPOSITORY_NAME}
 
-[View on OpenSAFELY](https://jobs.opensafely.org/repo/https%253A%252F%252Fgithub.com%252F${GITHUB_REPOSITORY_OWNER}%252F${GITHUB_REPOSITORY_NAME})
+[View on OpenSAFELY](https://jobs.opensafely.org/repo/https%253A%252F%252Fgithub.com%252Fopensafely%252F${GITHUB_REPOSITORY_NAME})
 
 Details of the purpose and any published outputs from this project can be found at the link above.
 


### PR DESCRIPTION
We're seeing users find the substitutions a little tricky, and to make matters worse confuse GitHub orgs with OpenSAFELY orgs.  Since we currently have no repos hosted in external orgs we're going to remove one of the steps for researchers.

Note: I've left the setup.yaml workflow as is so we can re-add the template string later if we need to.