### PR TITLE
Add ehrQL placeholders

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -1,0 +1,14 @@
+from ehrql import Dataset
+from ehrql.tables.beta.tpp import patients, practice_registrations
+
+dataset = Dataset()
+
+index_date = "2020-03-31"
+
+has_registration = practice_registrations.for_patient_on(
+    index_date
+).exists_for_patient()
+
+dataset.age = patients.age_on(index_date)
+
+dataset.define_population(has_registration & (dataset.age > 17))

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -1,3 +1,8 @@
+# Note: If you are using ehrQL to define your study population you need to:
+# (1) uncomment the ehrQL action in the project.yaml file (lines 14-18),
+# (2) delete the cohort-extractor action from the project.yaml file (lines 8-12), and
+# (3) delete the study_definition.py file.
+
 from ehrql import Dataset
 from ehrql.tables.beta.tpp import patients, practice_registrations
 

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -1,3 +1,7 @@
+# Note: If you are using cohortextrator to define your study population you need to
+# (1) delete the ehrQL action in the project.yaml file (lines 14-18) and
+# (2) delete the dataset_definition.py file.
+
 from cohortextractor import StudyDefinition, patients, codelist, codelist_from_csv  # NOQA
 
 

--- a/project.yaml
+++ b/project.yaml
@@ -10,3 +10,9 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/input.csv.gz
+
+  # generate_dataset:
+  #   run: ehrql:v0 generate-dataset analysis/dataset_definition.py --output output/dataset.csv.gz
+  #   outputs:
+  #     highly_sensitive:
+  #       cohort: output/dataset.csv.gz


### PR DESCRIPTION
This adds a placeholer ehrql dataset definition and action with instructions for cohortextractor and ehrql users at the top of each script (`dataset_definition.py` and `study_definition.py`).

This will be helpful for creating ehrQL documentation and examples because if gives us a starting point that is easy for users to get to. It's also a good to introduce ehrql in the research template simply because we are moving away from cohortextractor.

The `dataset_definition.py` is not a direct translation of the `study_definition.py` because I think it's good to use an ehrql method (`age_on`) in the example and show how a population can be defined using two conditions. 

However, we should have think if this is a good starting point for all studies that use the research-template or whether we want to make it more simple/complex?