### PR TITLE
Switch to ehrql v1

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -1,5 +1,5 @@
 from ehrql import create_dataset
-from ehrql.tables.beta.tpp import patients, practice_registrations
+from ehrql.tables.tpp import patients, practice_registrations
 
 dataset = create_dataset()
 

--- a/project.yaml
+++ b/project.yaml
@@ -6,7 +6,7 @@ expectations:
 
 actions:
   generate_dataset:
-    run: ehrql:v0 generate-dataset analysis/dataset_definition.py --output output/dataset.csv.gz
+    run: ehrql:v1 generate-dataset analysis/dataset_definition.py --output output/dataset.csv.gz
     outputs:
       highly_sensitive:
         dataset: output/dataset.csv.gz


### PR DESCRIPTION
Update to ehrql v1. This also required a change in the table imports because we no longer use `.beta`.