### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -32,7 +32,7 @@ jobs:
             https://api.github.com/repos/$GITHUB_REPOSITORY \
             | jq --exit-status '.is_template == false' || is_template=true
           # output true/false so later actions can be skipped
-          echo "::set-output name=is_template::$is_template"
+          echo "is_template=$is_template" >> $GITHUB_OUTPUT
       - name: Commit changes
         # only actually commit the changes if this is not a template repo
         if: steps.is_template.outputs.is_template == 'false'

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -32,7 +32,7 @@ jobs:
             https://api.github.com/repos/$GITHUB_REPOSITORY \
             | jq --exit-status '.is_template == false' || is_template=true
           # output true/false so later actions can be skipped
-          echo "is_template=$is_template" >> $GITHUB_OUTPUT
+          echo "is_template=$is_template" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         # only actually commit the changes if this is not a template repo
         if: steps.is_template.outputs.is_template == 'false'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


