### PR TITLE
Enable git autofetch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     },
     "files.autoSave": "afterDelay",
     "files.autoSaveDelay": 1000,
-    "git.autofetch": false,
+    "git.autofetch": true,
     "window.autoDetectColorScheme": true,
     "extensions.ignoreRecommendations": true,
     "data.preview.theme": "light"  


### PR DESCRIPTION
This matches the behaviour of GitHub Desktop and is likely to be the behaviour that users expect. If this causes any problems we can disable it again.