### PR TITLE
Revert "Disable git autofetch"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
     },
     "files.autoSave": "afterDelay",
     "files.autoSaveDelay": 1000,
-    "git.autofetch": false,
     "window.autoDetectColorScheme": true,
     "extensions.ignoreRecommendations": true,
     "data.preview.theme": "light"  


### PR DESCRIPTION
This reverts commit cf02a62fa19300f2639aac5c27be2d85b03ab23f.

This option will be moved into the devcontainer specific vscode config rather than the more general one, since the popups are a behaviour that are affecting Codespaces users.