### PR TITLE
Add read permission to opensafely/server-instructions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,15 @@
     },
     // Configure tool-specific properties.
     "customizations": {
+        "codespaces": {
+            "repositories": {
+                "opensafely/server-instructions": {
+                    "permissions": {
+                        "contents": "read"
+                    }
+                }
+            }
+        },
         "vscode": {
             "extensions": [
                 "ms-python.python",


### PR DESCRIPTION
This gives the auto-generated PAT used for git operations within this codespace read permissions to the server-instructions repo which contains the stata license file needed to run stata actions.

Fixes https://github.com/opensafely-core/research-template-docker/issues/27