### PR TITLE
Handle empty rstudio-prefs.json

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 #set R working directory
 ! grep -q "$1" $R_HOME/etc/Rprofile.site && sudo tee -a $R_HOME/etc/Rprofile.site <<< "setwd(\"$1\")"
 #set RStudio working directory
-! grep -q "$1" ~/.config/rstudio/rstudio-prefs.json && cat ~/.config/rstudio/rstudio-prefs.json | jq ". + {\"initial_working_directory\":\"$1\"}" >  ~/.config/rstudio/rstudio-prefs.json 
+if [ ! -s ~/.config/rstudio/rstudio-prefs.json ]; then nullinput="-n"; fi;
+! grep -q "$1" ~/.config/rstudio/rstudio-prefs.json && cat ~/.config/rstudio/rstudio-prefs.json | jq "$nullinput" ". + {\"initial_working_directory\":\"$1\"}" >  ~/.config/rstudio/rstudio-prefs.json 
 
 #download and extract latest ehrql source
 wget https://github.com/opensafely-core/ehrql/archive/main.zip -P .devcontainer


### PR DESCRIPTION
Based on [feedback](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1716892511090679) from @alschaffer there appear to be occasions when `rstudio-prefs.json` is empty at the time this script runs. 

In those instances the previous call to `jq` would return a null output and so the working directory preference would not be set.

We don't yet know what these circumstances are.

This PR proposes a way to handle the empty file, but we need to carefully test to ensure this setting persists beyond whatever process adds to this file in the circumstances described above.