### PR TITLE
Move `.devcontainer/.gitignore` into `.gitignore`

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,1 +1,0 @@
-ehrql-main

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv/
 .DS_Store
 .Rhistory
 .Rproj.user/
+.devcontainer/ehrql-main/


### PR DESCRIPTION
This change removes the need for a researcher to manually copy in the additional `.devcontainer/.gitignore`, when adding the Codespaces configuration to an existing repository. This step can be tricky as mentioned in #135.