### PR TITLE
Add year field to license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) {{organisation}}
+Copyright (c) {{current_year}} {{organisation}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This reverts commit a368dc6b0ebd989c90f87ff014a03844aad9dffd, and adds the year field back to the license file as it is a requirement.