### PR TITLE
Update project.yaml to latest version (5)

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,4 @@
-version: '4.0'
+version: '5.0'
 
 actions:
   generate_dataset:


### PR DESCRIPTION
Ensure new study repos created from this template use the current project.yaml version (v5 as of opensafely-pipeline version v2026.03.12.140752.

The pipeline library has been updated in [job-runner](https://github.com/opensafely-core/job-runner/pull/1367), [job-server](https://github.com/opensafely-core/job-server/pull/5686) and [opensafely-cli](https://github.com/opensafely-core/opensafely-cli/pull/385). 